### PR TITLE
Add support for version ranges

### DIFF
--- a/docs/McSherry.SemanticVersioning/Ranges/README.md
+++ b/docs/McSherry.SemanticVersioning/Ranges/README.md
@@ -1,0 +1,15 @@
+# `McSherry.SemanticVersioning.Ranges` namespace
+
+The `McSherry.SemanticVersioning.Ranges` namespace provides version range 
+functionality, intended to make complex comparisons against 
+[`SemanticVersion`][1] values easier to work with.
+
+[1]: ../SemanticVersion
+
+
+## Classes
+
+- **[VersionRange][2]**  
+  Represents a range of acceptable versions. This class cannot be inherited.
+  
+[2]: ./VersionRange

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/Parse(String).md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/Parse(String).md
@@ -1,0 +1,43 @@
+# `VersionRange.Parse` method
+
+```c#
+public static VersionRange Parse(
+    string range
+    )
+```
+
+**Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
+**Minimum version:** 1.1.0
+
+[1]: ../
+
+Parses a version range from a string.
+
+
+### Parameters
+
+- **`range`**  
+  **Type:** `System.String`  
+  The string representing the version range.
+  
+  
+### Return Value
+
+**Type:** [`McSherry.SemanticVersioning.Ranges.VersionRange`][2]
+
+A [VersionRange][2] equivalent to the value of _`range`_.
+
+[2]: ./
+
+
+## Exceptions
+
+- **`System.ArgumentNullException`**  
+  Thrown when _`ranges`_ is null, empty, or contains only
+  whitespace characters.
+- **`System.ArgumentException`**  
+  Thrown when _`range`_ is invalid for any reason unrelated to
+  an invalid semantic version string.
+- **`System.FormatException`**  
+  Thrown when _`range`_ contains an invalid semantic version
+  string.

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
@@ -6,7 +6,7 @@
 public sealed class VersionRange
 ```
 
-**Namespace:** [McSherry.SemanticVersioning.Ranges][1]  
+**Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
 **Minimum Version:** 1.1.0
 
 Represents a range of acceptable versions. This class cannot be

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
@@ -1,0 +1,64 @@
+# `VersionRange` class
+
+```c#
+[Serializable]
+[CLSCompliant(true)]
+public sealed class VersionRange
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Ranges][1]  
+**Minimum Version:** 1.1.0
+
+Represents a range of acceptable versions. This class cannot be
+inherited.
+
+[1]: ../
+
+
+## Constructors
+
+- **[VersionRange(String)][2]**  
+  Creates a version range from a string representing the range.
+  
+[2]: ./ctor(String).md
+
+
+## Instance Methods
+
+- **[SatisfiedBy(SemanticVersion)][3]**  
+  Determines whether the current version range is satisfied by
+  a specified [SemanticVersion][4].
+- **[SatisfiedBy(SemanticVersion[])][5]**  
+  Determines whether the current range is satisfied by all
+  specified [SemanticVersion][4] instances.
+  
+[3]: ./SatisfiedBy(SemanticVersion).md
+[4]: ../SemanticVersion
+[5]: ./SatisfiedBy(SemanticVersion[]).md
+
+
+## Static Methods
+
+- **[Parse(String)][6]**  
+  Parses a version range from a string.
+- **[TryParse(String, out SemanticVersion)][7]**  
+  Attempts to parse a version range from a string.
+  
+[6]: ./Parse(String).md
+[7]: ./TryParse(String,VersionRange).md
+
+
+## Remarks
+
+A version range specifies a set of semantic versions that are
+acceptable, and is used to check that a given semantic version
+fits within this set.
+
+Version ranges use the [`node-semver`][8] syntax for ranges.
+Specifically, ranges are based on the specification as it was
+written for the [`v5.0.0`][9] release of `node-semver`.
+
+Presently, only the basic range syntax is support.
+
+[8]: https://github.com/npm/node-semver
+[9]: https://github.com/npm/node-semver/blob/v5.0.0/README.md#ranges

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/README.md
@@ -58,7 +58,7 @@ Version ranges use the [`node-semver`][8] syntax for ranges.
 Specifically, ranges are based on the specification as it was
 written for the [`v5.0.0`][9] release of `node-semver`.
 
-Presently, only the basic range syntax is support.
+Presently, only the basic range syntax is supported.
 
 [8]: https://github.com/npm/node-semver
 [9]: https://github.com/npm/node-semver/blob/v5.0.0/README.md#ranges

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion).md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion).md
@@ -6,7 +6,7 @@ public bool SatisfiedBy(
     )
 ```
 
-**Namespace:** [McSherry.SemanticVersioning.Ranges][1]  
+**Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
 **Minimum version:** 1.1.0
 
 [1]: ../

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion).md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion).md
@@ -1,0 +1,33 @@
+# `VersionRange.SatisfiedBy(SemanticVersion)` method
+
+```c#
+public bool SatisfiedBy(
+    SemanticVersion semver
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Ranges][1]  
+**Minimum version:** 1.1.0
+
+[1]: ../
+
+Determines whether the current version range is satisfied
+by a specified [SemanticVersion][2].
+
+[2]: ../SemanticVersion
+
+
+### Parameters
+
+- **`semver`**  
+  **Type:** [`McSherry.SemanticVersioning.SemanticVersion`][2]  
+  The [SemanticVersion][2] to check against the current version
+  range.
+  
+
+### Return Value
+
+**Type:** `System.Boolean`
+
+True if the current version range is satisfied by _`semver`_, 
+false if otherwise.

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion[]).md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion[]).md
@@ -6,7 +6,7 @@ public bool SatisfiedBy(
     )
 ```
 
-**Namespace:** [McSherry.SemanticVersioning.Ranges][1]  
+**Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
 **Minimum version:** 1.1.0
 
 [1]: ../

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion[]).md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/SatisfiedBy(SemanticVersion[]).md
@@ -1,0 +1,33 @@
+# `VersionRange.SatisfiedBy(SemanticVersion[])` method
+
+```c#
+public bool SatisfiedBy(
+    params SemanticVersion[] semvers
+    )
+```
+
+**Namespace:** [McSherry.SemanticVersioning.Ranges][1]  
+**Minimum version:** 1.1.0
+
+[1]: ../
+
+Determines whether the current version range is satisfied
+by all specified [SemanticVersion][2] instances.
+
+[2]: ../SemanticVersion
+
+
+### Parameters
+
+- **`semver`**  
+  **Type:** [`McSherry.SemanticVersioning.SemanticVersion[]`][2]  
+  The [SemanticVersion][2] instances to check against the current
+  version range.
+  
+
+### Return Value
+
+**Type:** `System.Boolean`
+
+True if all [SemanticVersion][2] instances in _`semvers`_ satisfy the
+current range, false if otherwise.

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/TryParse(String,VersionRange).md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/TryParse(String,VersionRange).md
@@ -1,0 +1,35 @@
+# `VersionRange.TryParse(String, out VersionRange)` method
+
+```c#
+public static bool TryParse(
+    string range,
+    out VersionRange result
+    )
+```
+
+**Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
+**Minimum Version:** 1.1.0
+
+[1]: ../
+
+Attempts to parse a version range from a string.
+
+
+### Parameters
+
+- **`range`**  
+  **Type:** `System.String`  
+  The string representing the version range.
+- **`result`**  
+  **Type:** [`McSherry.SemanticVersioning.Ranges.VersionRange`][2]  
+  The [VersionRange][2] that, on success, is given a value
+  equivalent to _`range`_.
+  
+[2]: ./
+
+
+### Return Value
+
+**Type:** `System.Boolean`
+
+True on success, false on failure.

--- a/docs/McSherry.SemanticVersioning/Ranges/VersionRange/ctor(String).md
+++ b/docs/McSherry.SemanticVersioning/Ranges/VersionRange/ctor(String).md
@@ -1,0 +1,34 @@
+# `VersionRange` constructor
+
+```c#
+public VersionRange(
+    string range
+    )
+```
+
+**Namespace:** [`McSherry.SemanticVersioning.Ranges`][1]  
+**Minimum Version:** 1.1.0
+
+Creates a version range from a string representing the range.
+
+[1]: ../
+
+
+### Parameters
+
+- **`range`**  
+  **Type:** `System.String`  
+  The version range string from which to create an instance.
+  
+
+## Exceptions
+
+- **`System.ArgumentNullException`**  
+  Thrown when _`ranges`_ is null, empty, or contains only
+  whitespace characters.
+- **`System.ArgumentException`**  
+  Thrown when _`range`_ is invalid for any reason unrelated to
+  an invalid semantic version string.
+- **`System.FormatException`**  
+  Thrown when _`range`_ contains an invalid semantic version
+  string.

--- a/libSemVer.NET.Testing/Ranges/RangeIntlParsingTests.cs
+++ b/libSemVer.NET.Testing/Ranges/RangeIntlParsingTests.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) 2015 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace McSherry.SemanticVersioning.Ranges
+{
+    using static VersionRange;
+
+    /// <summary>
+    /// <para>
+    /// Provides the tests that test the internals of the version
+    /// range parser.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public sealed class RangeIntlParsingTests
+    {
+        private const string Category = "Version Range Parsing Internals";
+
+        /// <summary>
+        /// <para>
+        /// Tests the parser's identification of the basic version range
+        /// operators.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void BasicOperatorIdentification()
+        {
+            // Convenience function to extract the first comparator token
+            // from the set we get returned by the parse method.
+            var get = new Func<ParseResult, ComparatorToken>(
+                x => x.ComparatorSets.First().First()
+                );
+
+            // Each operator is tested twice: once with a prefixing 'v',
+            // and once without. We assume that, if testing with 'v' works,
+            // testing with 'V' would also work.
+            //
+            // The [Equal] operator is tested four times, as it can be both
+            // implicit and explicit in a range string.
+
+            var r0 = Parser.Parse("1.0.0");     // Equal
+            var r1 = Parser.Parse("v1.0.0");    // Equal
+            var r2 = Parser.Parse("=1.0.0");    // Equal
+            var r3 = Parser.Parse("=v1.0.0");   // Equal
+            var r4 = Parser.Parse("<1.0.0");    // LessThan
+            var r5 = Parser.Parse("<v1.0.0");   // LessThan
+            var r6 = Parser.Parse("<=1.0.0");   // LessThanOrEqual
+            var r7 = Parser.Parse("<=v1.0.0");  // LessThanOrEqual
+            var r8 = Parser.Parse(">1.0.0");    // GreaterThan
+            var r9 = Parser.Parse(">v1.0.0");   // GreaterThan
+            var r10 = Parser.Parse(">=1.0.0");  // GreaterThanOrEqual
+            var r11 = Parser.Parse(">=v1.0.0"); // GreaterThanOrEqual
+
+            Assert.AreEqual(Operator.Equal, get(r0).Operator,
+                            "Did not produce expected operator (0).");
+            Assert.AreEqual(Operator.Equal, get(r1).Operator,
+                            "Did not produce expected operator (1).");
+            Assert.AreEqual(Operator.Equal, get(r2).Operator,
+                            "Did not produce expected operator (2).");
+            Assert.AreEqual(Operator.Equal, get(r3).Operator,
+                            "Did not produce expected operator (3).");
+
+            Assert.AreEqual(Operator.LessThan, get(r4).Operator,
+                            "Did not produce expected operator (4).");
+            Assert.AreEqual(Operator.LessThan, get(r5).Operator,
+                            "Did not produce expected operator (5).");
+
+            Assert.AreEqual(Operator.LessThanOrEqual, get(r6).Operator,
+                            "Did not produce expected operator (6).");
+            Assert.AreEqual(Operator.LessThanOrEqual, get(r7).Operator,
+                            "Did not produce expected operator (7).");
+
+            Assert.AreEqual(Operator.GreaterThan, get(r8).Operator,
+                            "Did not produce expected operator (8).");
+            Assert.AreEqual(Operator.GreaterThan, get(r9).Operator,
+                            "Did not produce expected operator (9).");
+
+            Assert.AreEqual(Operator.GreaterThanOrEqual, get(r10).Operator,
+                            "Did not produce expected operator (10).");
+            Assert.AreEqual(Operator.GreaterThanOrEqual, get(r11).Operator,
+                            "Did not produce expected operator (11).");
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests the parser's ability to parse multiple comparators from
+        /// a string.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void MultipleComparatorParsing()
+        {
+            var cmpSet = Parser.Parse(">1.0.0 <=2.0.0 3.1.5")
+                               .ComparatorSets
+                               .First()
+                               .ToArray();
+
+            Assert.AreEqual(Operator.GreaterThan, cmpSet[0].Operator,
+                            "Did not produce expected operator (0).");
+            Assert.AreEqual(new SemanticVersion(1, 0), cmpSet[0].Version,
+                            "Did not produce expected version (0).");
+
+            Assert.AreEqual(Operator.LessThanOrEqual, cmpSet[1].Operator,
+                            "Did not produce expected operator (1).");
+            Assert.AreEqual(new SemanticVersion(2, 0), cmpSet[1].Version,
+                            "Did not produce expected version (1).");
+
+            Assert.AreEqual(Operator.Equal, cmpSet[2].Operator,
+                            "Did not produce expected operator (2).");
+            Assert.AreEqual(new SemanticVersion(3,1, 5), cmpSet[2].Version,
+                            "Did not produce expected version (2).");
+        }
+        /// <summary>
+        /// <para>
+        /// Tests the parser's ability to parse multiple comparator
+        /// sets from a string.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void MultipleSetParsing()
+        {
+            var cmpSetSet = Parser.Parse("=1.0.0 || >2.0.0 || <3.0.0")
+                                  .ComparatorSets
+                                  .Select(set => set.ToArray())
+                                  .ToArray();
+
+            Assert.AreEqual(1, cmpSetSet[0].Length,
+                            "Did not produce expected set length (0).");
+            Assert.AreEqual(Operator.Equal, cmpSetSet[0][0].Operator,
+                            "Did not produce expected operator (0).");
+            Assert.AreEqual(new SemanticVersion(1, 0), cmpSetSet[0][0].Version,
+                            "Did not produce expected version (0).");
+
+            Assert.AreEqual(1, cmpSetSet[1].Length,
+                            "Did not produce expected set length (1).");
+            Assert.AreEqual(Operator.GreaterThan, cmpSetSet[1][0].Operator,
+                            "Did not produce expected operator (1).");
+            Assert.AreEqual(new SemanticVersion(2, 0), cmpSetSet[1][0].Version,
+                            "Did not produce expected version (1).");
+
+            Assert.AreEqual(1, cmpSetSet[2].Length,
+                            "Did not produce expected set length (2).");
+            Assert.AreEqual(Operator.LessThan, cmpSetSet[2][0].Operator,
+                            "Did not produce expected operator (2).");
+            Assert.AreEqual(new SemanticVersion(3, 0), cmpSetSet[2][0].Version,
+                            "Did not produce expected version (2).");
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tests that the parser reports errors correctly.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void ParsingErrors()
+        {
+            // NullString
+            Assert.AreEqual(ParseResultType.NullString,
+                            Parser.Parse(null).Type,
+                            "Did not produce expected result code (0).");
+            Assert.AreEqual(ParseResultType.NullString,
+                            Parser.Parse("").Type,
+                            "Did not produce expected result code (1).");
+            Assert.AreEqual(ParseResultType.NullString,
+                            Parser.Parse("  \t ").Type,
+                            "Did not produce expected result code (2).");
+
+            // InvalidCharacter
+            Assert.AreEqual(ParseResultType.InvalidCharacter,
+                            Parser.Parse("1.0.0 | 2.0.0").Type,
+                            "Did not produce expected result code (3).");
+
+            // EmptySet
+            Assert.AreEqual(ParseResultType.EmptySet,
+                            Parser.Parse("||").Type,
+                            "Did not produce expected result code (4).");
+            Assert.AreEqual(ParseResultType.EmptySet,
+                            Parser.Parse("1.0.0 ||").Type,
+                            "Did not produce expected result code (5).");
+            Assert.AreEqual(ParseResultType.EmptySet,
+                            Parser.Parse("|| 1.0.0").Type,
+                            "Did not produce expected result code (6).");
+            Assert.AreEqual(ParseResultType.EmptySet,
+                            Parser.Parse("1.0.0 || || 1.2.3").Type,
+                            "Did not produce expected result code (7).");
+
+            // OrphanedOperator
+            Assert.AreEqual(ParseResultType.OrphanedOperator,
+                            Parser.Parse("= 1.0.0").Type,
+                            "Did not produce expected result code (8).");
+            Assert.AreEqual(ParseResultType.OrphanedOperator,
+                            Parser.Parse("> 1.0.0").Type,
+                            "Did not produce expected result code (9).");
+            Assert.AreEqual(ParseResultType.OrphanedOperator,
+                            Parser.Parse("< 1.0.0").Type,
+                            "Did not produce expected result code (10).");
+            Assert.AreEqual(ParseResultType.OrphanedOperator,
+                            Parser.Parse(">= 1.0.0").Type,
+                            "Did not produce expected result code (11).");
+            Assert.AreEqual(ParseResultType.OrphanedOperator,
+                            Parser.Parse("<= 1.0.0").Type,
+                            "Did not produce expected result code (12).");
+
+            // InvalidVersion
+            Assert.AreEqual(ParseResultType.InvalidVersion,
+                            Parser.Parse("1.0.0-früh").Type,
+                            "Did not produce expected result code (13).");
+        }
+    }
+}

--- a/libSemVer.NET.Testing/Ranges/RangeTests.cs
+++ b/libSemVer.NET.Testing/Ranges/RangeTests.cs
@@ -85,5 +85,69 @@ namespace McSherry.SemanticVersioning.Ranges
             
             Assert.IsFalse(vr3.SatisfiedBy(sv2), "Incorrect acceptance (6).");
         }
+
+        /// <summary>
+        /// <para>
+        /// Tests version range comparison using a single comparator set with
+        /// multiple comparators in it.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void MultipleComparators()
+        {
+            // This test is taken from the README of the 'node-semver'
+            // repository, because what better source than the horse's
+            // mouth?
+            //
+            // We only have a single test because we have another test
+            // for the individual comparators, we just want to make sure
+            // that multiple comparators are treated as expected.
+            VersionRange vr0 = new VersionRange(">=1.2.7 <1.3.0")
+                        ;
+
+            SemanticVersion sv0 = new SemanticVersion(1, 2, 7), // These three are
+                            sv1 = new SemanticVersion(1, 2, 8), // matches.
+                            sv2 = new SemanticVersion(1, 2, 99),
+                            sv3 = new SemanticVersion(1, 2, 6), // And these are
+                            sv4 = new SemanticVersion(1, 3, 0), // mismatches.
+                            sv5 = new SemanticVersion(1, 1, 0)
+                            ;
+
+            Assert.IsTrue(vr0.SatisfiedBy(sv0), "Incorrect rejection (0).");
+            Assert.IsTrue(vr0.SatisfiedBy(sv1), "Incorrect rejection (1).");
+            Assert.IsTrue(vr0.SatisfiedBy(sv2), "Incorrect rejection (2).");
+
+            Assert.IsFalse(vr0.SatisfiedBy(sv3), "Incorrect acceptance (0).");
+            Assert.IsFalse(vr0.SatisfiedBy(sv4), "Incorrect acceptance (1).");
+            Assert.IsFalse(vr0.SatisfiedBy(sv5), "Incorrect acceptance (2).");
+        }
+        /// <summary>
+        /// <para>
+        /// Tests version range comparison using multiple comparator sets.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void MultipleComparatorSets()
+        {
+            // Like in the [MultipleComparators] test, this test is straight
+            // from the 'node-semver' README, and there's only a single test
+            // because individual comparators and multiple comparators are
+            // already tested.
+            VersionRange vr0 = new VersionRange("1.2.7 || >=1.2.9 <2.0.0");
+
+            SemanticVersion sv0 = new SemanticVersion(1, 2, 7), // These match.
+                            sv1 = new SemanticVersion(1, 2, 9),
+                            sv2 = new SemanticVersion(1, 4, 6),
+                            sv3 = new SemanticVersion(1, 2, 8), // These don't.
+                            sv4 = new SemanticVersion(2, 0, 0)
+                                ;
+
+            Assert.IsTrue(vr0.SatisfiedBy(sv0), "Incorrect rejection (0).");
+            Assert.IsTrue(vr0.SatisfiedBy(sv1), "Incorrect rejection (1).");
+            Assert.IsTrue(vr0.SatisfiedBy(sv2), "Incorrect rejection (2).");
+
+            Assert.IsFalse(vr0.SatisfiedBy(sv3), "Incorrect acceptance (0).");
+            Assert.IsFalse(vr0.SatisfiedBy(sv4), "Incorrect acceptance (1).");
+        }
     }
 }

--- a/libSemVer.NET.Testing/Ranges/RangeTests.cs
+++ b/libSemVer.NET.Testing/Ranges/RangeTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) 2015 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace McSherry.SemanticVersioning.Ranges
+{
+    /// <summary>
+    /// <para>
+    /// Provides tests for the base <see cref="VersionRange"/> functionality.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public sealed class RangeTests
+    {
+        private const string Category = "Version Range Base";
+
+        /// <summary>
+        /// <para>
+        /// Tests version range comparison using the basic operators with
+        /// a single comparator in each range.
+        /// </para>
+        /// </summary>
+        [TestMethod, TestCategory(Category)]
+        public void BasicComparison()
+        {
+            VersionRange    vr0 = new VersionRange("1.2.3"),
+                            vr1 = new VersionRange("=1.2.3"),
+                            vr2 = new VersionRange(">1.2.3"),
+                            vr3 = new VersionRange("<1.2.3"),
+                            vr4 = new VersionRange(">=1.2.3"),
+                            vr5 = new VersionRange("<=1.2.3")
+                            ;
+
+            SemanticVersion sv0 = new SemanticVersion(1, 2, 3),
+                            sv1 = new SemanticVersion(1, 2, 2),
+                            sv2 = new SemanticVersion(1, 2, 3, new[] { "alpha" }),
+                            sv3 = new SemanticVersion(1, 2, 4),
+                            sv4 = new SemanticVersion(1, 2, 4, new[] { "alpha" })
+                            ;
+
+            // Testing satisfaction
+            Assert.IsTrue(vr0.SatisfiedBy(sv0), "Incorrect rejection (0).");
+            Assert.IsTrue(vr1.SatisfiedBy(sv0), "Incorrect rejection (1).");
+            Assert.IsTrue(vr2.SatisfiedBy(sv3), "Incorrect rejection (2).");
+
+            Assert.IsTrue(vr4.SatisfiedBy(sv0), "Incorrect rejection (4).");
+            Assert.IsTrue(vr4.SatisfiedBy(sv3), "Incorrect rejection (5).");
+
+            Assert.IsTrue(vr5.SatisfiedBy(sv0), "Incorrect rejection (6).");
+            Assert.IsTrue(vr5.SatisfiedBy(sv1), "Incorrect rejection (7).");
+
+            Assert.IsTrue(vr2.SatisfiedBy(sv4), "Incorrect rejection (8).");
+            Assert.IsTrue(vr4.SatisfiedBy(sv4), "Incorrect rejection (9).");
+
+            // And testing dissatisfaction
+            Assert.IsFalse(vr0.SatisfiedBy(sv1), "Incorrect acceptance (0).");
+            Assert.IsFalse(vr0.SatisfiedBy(sv2), "Incorrect acceptance (1).");
+            Assert.IsFalse(vr0.SatisfiedBy(sv3), "Incorrect acceptance (2).");
+            Assert.IsFalse(vr1.SatisfiedBy(sv1), "Incorrect acceptance (3).");
+            Assert.IsFalse(vr1.SatisfiedBy(sv2), "Incorrect acceptance (4).");
+            Assert.IsFalse(vr1.SatisfiedBy(sv3), "Incorrect acceptance (5).");
+            
+            Assert.IsFalse(vr3.SatisfiedBy(sv2), "Incorrect acceptance (6).");
+        }
+    }
+}

--- a/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
+++ b/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
@@ -59,6 +59,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Ranges\RangeIntlParsingTests.cs" />
     <Compile Include="SemanticVersionIntlParsingTests.cs" />
     <Compile Include="SemanticVersionParsingTests.cs" />
     <Compile Include="SemanticVersionTests.cs" />

--- a/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
+++ b/libSemVer.NET.Testing/libSemVer.NET.Testing.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Ranges\RangeIntlParsingTests.cs" />
+    <Compile Include="Ranges\RangeTests.cs" />
     <Compile Include="SemanticVersionIntlParsingTests.cs" />
     <Compile Include="SemanticVersionParsingTests.cs" />
     <Compile Include="SemanticVersionTests.cs" />

--- a/libSemVer.NET/Helper.cs
+++ b/libSemVer.NET/Helper.cs
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -123,6 +125,31 @@ namespace McSherry.SemanticVersioning
         public static bool IsNumber(char c)
         {
             return c >= '0' && c <= '9';
+        }
+
+        /// <summary>
+        /// <para>
+        /// Returns a read-only <see cref="IReadOnlyDictionary{TKey, TValue}"/>
+        /// wrapper of the specified <see cref="IDictionary{TKey, TValue}"/>.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="K">
+        /// The type of the dictionary's keys.
+        /// </typeparam>
+        /// <typeparam name="V">
+        /// The type of the dictionary's values.
+        /// </typeparam>
+        /// <param name="dictionary">
+        /// The <see cref="IDictionary{TKey, TValue}"/> to wrap.
+        /// </param>
+        /// <returns>
+        /// A read-only wrapper of <paramref name="dictionary"/>.
+        /// </returns>
+        public static IReadOnlyDictionary<K, V> AsReadOnly<K, V>(
+            this IDictionary<K, V> dictionary
+            )
+        {
+            return new ReadOnlyDictionary<K, V>(dictionary);
         }
     }
 }

--- a/libSemVer.NET/Ranges/VersionRange.Comparison.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Comparison.cs
@@ -1,0 +1,286 @@
+﻿// Copyright (c) 2015 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace McSherry.SemanticVersioning.Ranges
+{
+    // Documentation and attributes are in 'Ranges\VersionRange.cs'
+    public sealed partial class VersionRange
+    {
+        /// <summary>
+        /// <para>
+        /// Represents an implementation of a comparator.
+        /// </para>
+        /// </summary>
+        private interface IComparator
+        {
+            /*
+                So, why bother with this interface if it's private and
+                we've only got one class implementing it, and that class
+                is little more than a shell?
+
+                Answer: future proofing.
+
+                Currently, we only support the basic features of version
+                ranges specified by the 'node-semver' docs, but in future
+                we're likely to support the advanced features, and the
+                advanced features all decompose into a set of the basic
+                features.
+
+                By having this interface here from the start, we don't need
+                to do a large amount of rework, we just need to make the
+                [VersionRange] class implement the interface, we need to 
+                add the appropriate [Operator] values for the advanced features,
+                and we then make [Comparator.Create] return [VersionRange]s
+                for advanced features, and that's that. It'll also be entirely
+                transparent to the [VersionRange] consuming it, which is a big
+                plus.
+            */
+
+            /// <summary>
+            /// <para>
+            /// Determines whether the comparator is satisfied
+            /// by a specified <see cref="SemanticVersion"/>.
+            /// </para>
+            /// </summary>
+            /// <param name="comparand">
+            /// The <see cref="SemanticVersion"/> to check
+            /// against the comparator.
+            /// </param>
+            /// <returns>
+            /// True if the comparator is satisfied by the
+            /// specified semantic version, false if otherwise.
+            /// </returns>
+            bool SatisfiedBy(SemanticVersion comparand);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Implements comparison using the <see cref="ComparatorToken"/>
+        /// instances produced by the <see cref="Parser"/>.
+        /// </para>
+        /// </summary>
+        private sealed class Comparator : IComparator
+        {
+            /// <summary>
+            /// <para>
+            /// Represents a method implementing a comparator.
+            /// </para>
+            /// </summary>
+            /// <param name="comparand">
+            /// The <see cref="SemanticVersion"/> that is being compared
+            /// against the version specified in the <see cref="ComparatorToken"/>.
+            /// </param>
+            /// <param name="comparator">
+            /// The <see cref="SemanticVersion"/> that the version being
+            /// checked is compared against. This is the version that is
+            /// specified in the <see cref="ComparatorToken"/>.
+            /// </param>
+            /// <returns>
+            /// True if the comparator is satisfied, false if otherwise.
+            /// </returns>
+            private delegate bool ComparatorImpl(SemanticVersion comparand,
+                                                 SemanticVersion comparator);
+
+            private static readonly IReadOnlyDictionary<Operator, ComparatorImpl>
+                Comparers;
+
+            private static bool OpEqual(SemanticVersion arg, 
+                                        SemanticVersion comparator)
+            {
+                // We don't care about metadata when we're comparing with
+                // version ranges, so we use [EquivalentTo] so that those
+                // items are ignored.
+                return arg.EquivalentTo(comparator);
+            }
+            private static bool OpLess(SemanticVersion arg,
+                                       SemanticVersion comparator)
+            {
+                // This one's slightly trickier since it isn't a direct
+                // translation to one of the [SemanticVersion] operators or
+                // methods.
+
+                // Generally, a "less than" comparison will be a simple
+                // precedence comparison, but in certain situations we need
+                // to do some extra work.
+                //
+                // If the comparator version ([ca]) has pre-release identifiers,
+                // then we need to check whether the comparand ([c]) has them as
+                // well. If it does, [c] and [ca] must have the same 
+                // major -minor-patch trio for [c] to satisfy the comparator.
+                // However, if [c] does not have identifiers, then a simple
+                // precedence comparison will work.
+                //
+                // Example:
+                //
+                //      Comparator:     <1.2.3-alpha.5
+                //
+                //      +---------------+------------+
+                //      | Comparand     | Satisfies? |
+                //      +---------------+------------+
+                //      | 1.2.3         | False      |
+                //      | 1.2.3-alpha.4 | True       |
+                //      | 1.2.3-alpha.6 | False      |
+                //      | 1.2.2         | True       |
+                //      | 1.2.2-alpha.1 | False      |
+                //      | 2.3.4         | False      |
+                //      | 2.3.4-alpha.1 | False      |
+                //      +---------------+------------+
+                //
+                // The 'node-semver' documentation justifies this behaviour by
+                // saying that a user, by specifying a comparator with pre-release
+                // identifiers, has stated that they are okay with pre-releases of
+                // the same version, but not of any other version.
+
+
+                // If both versions have identifiers, they must have the same
+                // major-minor-patch trio. If not, then we must return false.
+                if (arg.Identifiers.Any() && comparator.Identifiers.Any())
+                {
+                    if (comparator.Major != arg.Major ||
+                        comparator.Minor != arg.Minor ||
+                        comparator.Patch != arg.Patch)
+                        return false;
+                }
+                // If the comparator doesn't have pre-release identifiers but
+                // the comparand does, then we want to return false.
+                else if (arg.Identifiers.Any())
+                {
+                    return false;
+                }
+
+                return arg < comparator;
+            }
+            private static bool OpGreater(SemanticVersion arg,
+                                          SemanticVersion comparator)
+            {
+                // This function is going to be mostly the same as [OpLess], just
+                // using a greater-than precedence comparison instead of a
+                // less-than comparison.
+                //
+                // As a result, any comments that would be practical duplicates
+                // are omitted. See the body of [OpLess] for roughly equivalent
+                // comments.
+
+                if (arg.Identifiers.Any() && comparator.Identifiers.Any())
+                {
+                    if (comparator.Major != arg.Major ||
+                        comparator.Minor != arg.Minor ||
+                        comparator.Patch != arg.Patch)
+                        return false;
+                }
+                else if (arg.Identifiers.Any())
+                {
+
+                }
+
+                return arg > comparator;
+            }
+            private static bool OpLTEQ(SemanticVersion arg,
+                                       SemanticVersion comparator)
+            {
+                return OpEqual(arg, comparator) || OpLess(arg, comparator);
+            }
+            private static bool OpGTEQ(SemanticVersion arg,
+                                       SemanticVersion comparator)
+            {
+                return OpEqual(arg, comparator) || OpGreater(arg, comparator);
+            }
+
+            static Comparator()
+            {
+                Comparers = new Dictionary<Operator, ComparatorImpl>
+                {
+                    [Operator.Equal]                = OpEqual,
+                    [Operator.LessThan]             = OpLess,
+                    [Operator.GreaterThan]          = OpGreater,
+                    [Operator.LessThanOrEqual]      = OpLTEQ,
+                    [Operator.GreaterThanOrEqual]   = OpGTEQ,
+                }.AsReadOnly();
+            }
+
+            /// <summary>
+            /// <para>
+            /// Creates a new <see cref="IComparator"/> using the specified
+            /// <see cref="ComparatorToken"/>.
+            /// </para>
+            /// </summary>
+            /// <param name="cmp">
+            /// The <see cref="ComparatorToken"/> to create an equivalent
+            /// <see cref="IComparator"/> for.
+            /// </param>
+            /// <returns>
+            /// An <see cref="IComparator"/> instance that implements the
+            /// comparison function represented by the specified
+            /// <see cref="ComparatorToken"/>.
+            /// </returns>
+            /// <exception cref="ArgumentException">
+            /// Thrown when <paramref name="cmp"/> has an unrecognised
+            /// <see cref="ComparatorToken.Operator"/> value.
+            /// </exception>
+            public static IComparator Create(ComparatorToken cmp)
+            {
+                ComparatorImpl cmpImpl;
+                if (!Comparers.TryGetValue(cmp.Operator, out cmpImpl))
+                {
+                    throw new ArgumentException(
+                        message:    "Unrecognised operator.",
+                        paramName:  nameof(cmp));
+                }
+
+                return new Comparator(sv => cmpImpl(sv, cmp.Version));
+            }
+
+            private readonly Predicate<SemanticVersion> _cmpFn;
+
+            /// <summary>
+            /// <para>
+            /// Creates a new <see cref="Comparator"/> with the specified
+            /// function as its comparison function.
+            /// </para>
+            /// </summary>
+            /// <param name="impl">
+            /// The function to use as the comparison function.
+            /// </param>
+            private Comparator(Predicate<SemanticVersion> impl)
+            {
+                if (impl == null)
+                {
+                    throw new ArgumentNullException(
+                        paramName: nameof(impl),
+                        message: "Comparator implementation cannot " +
+                                    "be null."
+                        );
+                }
+
+                _cmpFn = impl;
+            }
+
+            bool IComparator.SatisfiedBy(SemanticVersion comparand)
+            {
+                return _cmpFn(comparand);
+            }
+        }
+    }
+}

--- a/libSemVer.NET/Ranges/VersionRange.Comparison.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Comparison.cs
@@ -190,10 +190,6 @@ namespace McSherry.SemanticVersioning.Ranges
                         comparator.Patch != arg.Patch)
                         return false;
                 }
-                else if (arg.Identifiers.Any())
-                {
-
-                }
 
                 return arg > comparator;
             }

--- a/libSemVer.NET/Ranges/VersionRange.Comparison.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Comparison.cs
@@ -20,8 +20,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace McSherry.SemanticVersioning.Ranges
 {

--- a/libSemVer.NET/Ranges/VersionRange.Parsing.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Parsing.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2015 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace McSherry.SemanticVersioning.Ranges
+{
+    // Documentation and attributes are in 'Ranges\VersionRange.cs'
+    public sealed partial class VersionRange
+    {
+        /// <summary>
+        /// <para>
+        /// Represents the operators that the <see cref="VersionRange"/>
+        /// parser recognises.
+        /// </para>
+        /// </summary>
+        private enum Operator
+        {
+            /// <summary>
+            /// <para>
+            /// Used to check version equality. Assumed when no operator
+            /// is specified.
+            /// </para>
+            /// </summary>
+            Equal,
+            /// <summary>
+            /// <para>
+            /// Used in checking that a <see cref="SemanticVersion"/> has
+            /// lesser precedence than the specified version.
+            /// </para>
+            /// </summary>
+            LessThan,
+            /// <summary>
+            /// <para>
+            /// Used in checking that a <see cref="SemanticVersion"/> has
+            /// greater precedence than the specified version.
+            /// </para>
+            /// </summary>
+            GreaterThan,
+            /// <summary>
+            /// <para>
+            /// Used in checking that a <see cref="SemanticVersion"/> is
+            /// equal or has lesser precedence than the specified version.
+            /// </para>
+            /// </summary>
+            LessThanOrEqual,
+            /// <summary>
+            /// <para>
+            /// Used in checking that a <see cref="SemanticVersion"/> is
+            /// equal or has greater precedence than the specified version.
+            /// </para>
+            /// </summary>
+            GreaterThanOrEqual,
+        }
+
+        /// <summary>
+        /// <para>
+        /// Represents an <see cref="Operator"/> and <see cref="SemanticVersion"/>
+        /// grouping identified by the parser.
+        /// </para>
+        /// </summary>
+        private struct Comparator
+        {
+            private readonly Operator _op;
+            private readonly SemanticVersion _sv;
+            private readonly bool _valid;
+
+            /// <summary>
+            /// <para>
+            /// Ensures that the the current instance has been
+            /// correctly constructed and is valid.
+            /// </para>
+            /// </summary>
+            /// <typeparam name="T">
+            /// The type of the value to pass through on valid
+            /// construction.
+            /// </typeparam>
+            /// <param name="passthrough">
+            /// A value to be passed through if the current
+            /// instance is valid.
+            /// </param>
+            /// <returns>
+            /// If the current instance is valid, returns the
+            /// value given in <paramref name="passthrough"/>.
+            /// Otherwise, throws an exception.
+            /// </returns>
+            /// <exception cref="InvalidOperationException">
+            /// Thrown when the current instance is not valid.
+            /// </exception>
+            private T Validate<T>(T passthrough)
+            {
+                if (_valid)
+                    return passthrough;
+
+                throw new InvalidOperationException(
+                    "An attempt was made to use a Comparator that was " +
+                    "not correctly constructed."
+                    );
+            }
+
+            /// <summary>
+            /// <para>
+            /// Creates a new <see cref="Comparator"/> instance with
+            /// the specified operator and semantic version.
+            /// </para>
+            /// </summary>
+            /// <param name="op">
+            /// The <see cref="VersionRange.Operator"/> to use.
+            /// </param>
+            /// <param name="semver">
+            /// The <see cref="SemanticVersion"/> to use.
+            /// </param>
+            /// <exception cref="ArgumentNullException">
+            /// Thrown when <paramref name="semver"/> is null.
+            /// </exception>
+            /// <exception cref="ArgumentException">
+            /// Thrown when <paramref name="op"/> is not a recognised
+            /// <see cref="VersionRange.Operator"/>.
+            /// </exception>
+            public Comparator(Operator op, SemanticVersion semver)
+            {
+                if (semver == null)
+                {
+                    throw new ArgumentNullException(
+                        message:    "The specified version cannot be null.",
+                        paramName:  nameof(semver)
+                        );
+                }
+
+                if (!Enum.IsDefined(typeof(Operator), op))
+                {
+                    throw new ArgumentException(
+                        message:    "The specified operator is not valid.",
+                        paramName:  nameof(op)
+                        );
+                }
+
+                _op = op;
+                _sv = semver;
+                _valid = true;
+            }
+
+            /// <summary>
+            /// <para>
+            /// The operator used during comparison.
+            /// </para>
+            /// </summary>
+            public Operator Operator => Validate(_op);
+            /// <summary>
+            /// <para>
+            /// The semantic version that is compared against.
+            /// </para>
+            /// </summary>
+            public SemanticVersion Version => Validate(_sv);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Implements parsing for version ranges.
+        /// </para>
+        /// </summary>
+        private static class Parser
+        {
+
+        }
+    }
+}

--- a/libSemVer.NET/Ranges/VersionRange.Parsing.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Parsing.cs
@@ -1058,7 +1058,9 @@ namespace McSherry.SemanticVersioning.Ranges
         /// </exception>
         public static VersionRange Parse(string range)
         {
-            throw new NotImplementedException();
+            // This constructor does all the same stuff as this method would
+            // do, so we might as well just call it instead of reimplementing.
+            return new VersionRange(range);
         }
         /// <summary>
         /// <para>
@@ -1077,7 +1079,27 @@ namespace McSherry.SemanticVersioning.Ranges
         /// </returns>
         public static bool TryParse(string range, out VersionRange result)
         {
-            throw new NotImplementedException();
+            var parseResult = Parser.Parse(range);
+
+            // If the parsing wasn't successful, set [result] to null and
+            // return false to indicate failure.
+            if (parseResult.Type != Success)
+            {
+                result = null;
+                return false;
+            }
+
+            // If parsing was successful, then exchange all of the comparator
+            // tokens we were given for [IComparator] instances that we can
+            // pass to a constructor.
+            var comparators = parseResult.ComparatorSets.Select(
+                tokenSet => tokenSet.Select(
+                    token => Comparator.Create(token)
+                    )
+                );
+
+            result = new VersionRange(comparators);
+            return true;
         }
     }
 }

--- a/libSemVer.NET/Ranges/VersionRange.Parsing.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Parsing.cs
@@ -367,7 +367,7 @@ namespace McSherry.SemanticVersioning.Ranges
 
                 _type = error;
                 _results = null;
-                _innerEx = null;
+                _innerEx = new Lazy<Exception>(() => null);
                 _successfulCreation = true;
             }
             /// <summary>

--- a/libSemVer.NET/Ranges/VersionRange.Parsing.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Parsing.cs
@@ -23,8 +23,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using static McSherry.SemanticVersioning.Ranges.VersionRange.ParseResultType;
+
 namespace McSherry.SemanticVersioning.Ranges
 {
+    using ResultSet = IEnumerable<IEnumerable<VersionRange.ComparatorToken>>;
+
     // Documentation and attributes are in 'Ranges\VersionRange.cs'
     public sealed partial class VersionRange
     {
@@ -34,7 +38,7 @@ namespace McSherry.SemanticVersioning.Ranges
         /// parser recognises.
         /// </para>
         /// </summary>
-        private enum Operator
+        internal enum Operator
         {
             /// <summary>
             /// <para>
@@ -79,7 +83,7 @@ namespace McSherry.SemanticVersioning.Ranges
         /// grouping identified by the parser.
         /// </para>
         /// </summary>
-        private struct ComparatorToken
+        internal struct ComparatorToken
         {
             private readonly Operator _op;
             private readonly SemanticVersion _sv;
@@ -176,10 +180,251 @@ namespace McSherry.SemanticVersioning.Ranges
 
         /// <summary>
         /// <para>
+        /// Represents the various possible return statuses of the
+        /// <see cref="VersionRange"/> parser.
+        /// </para>
+        /// </summary>
+        internal enum ParseResultType
+        {
+            /// <summary>
+            /// <para>
+            /// Parsing completed without issue.
+            /// </para>
+            /// </summary>
+            Success,
+
+            /// <summary>
+            /// <para>
+            /// The version range string contains an invalid
+            /// semantic version string.
+            /// </para>
+            /// </summary>
+            InvalidVersion,
+        }
+
+        /// <summary>
+        /// <para>
+        /// Represents the result produced by the <see cref="VersionRange"/>
+        /// parser.
+        /// </para>
+        /// </summary>
+        internal struct ParseResult
+        {
+            // Certain codes are required to be provided with an exception. This
+            // hashset will contain those specific codes so we can check for them.
+            private static readonly HashSet<ParseResultType> _exCodes;
+
+            static ParseResult()
+            {
+                _exCodes = new HashSet<ParseResultType>
+                {
+                    // [InvalidVersion] needs an exception so that the exact
+                    // reason for the version string being invalid can be relayed.
+                    InvalidVersion,
+                };
+            }
+
+            // This will be false if we're default-constructed.
+            private readonly bool _successfulCreation;
+            // Property backing fields.
+            private readonly ParseResultType _type;
+            private readonly ResultSet _results;
+            private readonly Exception _innerEx;
+
+            /// <summary>
+            /// <para>
+            /// Checks the <see cref="_successfulCreation"/> field,
+            /// and throws if it is false.
+            /// </para>
+            /// </summary>
+            /// <typeparam name="T">
+            /// The type of the value to be returned on success.
+            /// </typeparam>
+            /// <param name="passthrough">
+            /// A value to be returned from the function if the
+            /// <see cref="ParseResult"/> was successfully constructed.
+            /// </param>
+            /// <returns>
+            /// If <see cref="_successfulCreation"/> is true, returns
+            /// <paramref name="passthrough"/>.
+            /// </returns>
+            /// <exception cref="InvalidOperationException">
+            /// Thrown when <see cref="_successfulCreation"/> is false.
+            /// </exception>
+            private T VerifyResult<T>(T passthrough)
+            {
+                if (_successfulCreation)
+                    return passthrough;
+
+                throw new InvalidOperationException(
+                    "Attempt to use a [VersionRange.ParseResult] that was " +
+                    "default-constructed.");
+            }
+
+            /// <summary>
+            /// <para>
+            /// Creates a parse result indicating success and
+            /// containing the specified results.
+            /// </para>
+            /// </summary>
+            /// <param name="results">
+            /// The results for the <see cref="ParseResult"/>
+            /// to contain.
+            /// </param>
+            /// <exception cref="ArgumentNullException">
+            /// Thrown when <paramref name="results"/> or
+            /// any of its items are null.
+            /// </exception>
+            public ParseResult(ResultSet results)
+            {
+                if (results?.Any(cs => cs == null) != false)
+                {
+                    throw new ArgumentNullException(
+                        paramName:  nameof(results),
+                        message:    "The result set cannot be null, and " +
+                                    "cannot contain null items."
+                        );
+                }
+
+                _type = ParseResultType.Success;
+                _results = results;
+                _innerEx = null;
+                _successfulCreation = true;
+            }
+            /// <summary>
+            /// <para>
+            /// Creates a parse result indicating failure and
+            /// with the specified result code.
+            /// </para>
+            /// </summary>
+            /// <param name="error">
+            /// The result code for the <see cref="ParseResult"/>
+            /// to report.
+            /// </param>
+            /// <exception cref="ArgumentException">
+            /// Thrown when <paramref name="error"/> is invalid
+            /// or unrecognised.
+            /// </exception>
+            public ParseResult(ParseResultType error)
+            {
+                if (error == Success)
+                {
+                    throw new ArgumentException(
+                        message:    "A failure-state [VR.ParseResult] cannot " +
+                                    "be created with the [Success] status.",
+                        paramName:  nameof(error));
+                }
+
+                if (!Enum.IsDefined(typeof(ParseResultType), error))
+                {
+                    throw new ArgumentException(
+                        message:    $"The parse result code {(int)error:X8} is " +
+                                     "not recognised.",
+                        paramName:  nameof(error));
+                }
+
+                // Some status codes must be provided with an exception. We
+                // need to check for these in this constructor, as this ctor
+                // doesn't take an exception argument.
+                if (_exCodes.Contains(error))
+                {
+                    throw new ArgumentException(
+                        message:    $"The parse result code {(int)error:X8} is " +
+                                     "required to be passed with an exception.",
+                        paramName:  nameof(error));
+                }
+
+                _type = error;
+                _results = null;
+                _innerEx = null;
+                _successfulCreation = true;
+            }
+            /// <summary>
+            /// <para>
+            /// Creates a parse result indicating failure and with
+            /// the specified error code and inner exception.
+            /// </para>
+            /// </summary>
+            /// <param name="error">
+            /// The result code for the <see cref="ParseResult"/>
+            /// to report.
+            /// </param>
+            /// <param name="innerException">
+            /// The inner exception to store in the parse result.
+            /// </param>
+            /// <exception cref="ArgumentNullException">
+            /// Thrown when <paramref name="innerException"/> is null.
+            /// </exception>
+            /// <exception cref="ArgumentException">
+            /// Thrown when <paramref name="error"/> is invalid
+            /// or unrecognised.
+            /// </exception>
+            public ParseResult(ParseResultType error, Exception innerException)
+                : this(error)
+            {
+                if (error == Success)
+                {
+                    throw new ArgumentException(
+                        message:    "A failure-state [VR.ParseResult] cannot " +
+                                    "be created with the [Success] status.",
+                        paramName:  nameof(error));
+                }
+
+                if (innerException == null)
+                {
+                    throw new ArgumentNullException(
+                        paramName:  nameof(innerException),
+                        message:    "The provided inner exception cannot " +
+                                    "be null."
+                        );
+                }
+
+                if (!Enum.IsDefined(typeof(ParseResultType), error))
+                {
+                    throw new ArgumentException(
+                        message:    $"The parse result code {(int)error:X8} is " +
+                                     "not recognised.",
+                        paramName:  nameof(error));
+                }
+
+                // We want to make sure that the code we've been passed is one of
+                // the ones that has to be passed with an exception. If it isn't,
+                // then we want to throw an exception.
+                if (!_exCodes.Contains(error))
+                {
+                    throw new ArgumentException(
+                        message:   $"The parse result code {(int)error:X8} must" +
+                                    " not be passed with an exception.",
+                        paramName: nameof(error));
+                }
+
+                _type = error;
+                _results = null;
+                _innerEx = innerException;
+                _successfulCreation = true;
+            }
+
+            /// <summary>
+            /// <para>
+            /// The result code describing the parse result.
+            /// </para>
+            /// </summary>
+            public ParseResultType Type => VerifyResult(_type);
+            /// <summary>
+            /// <para>
+            /// The collection of comparator sets produced by the
+            /// parser.
+            /// </para>
+            /// </summary>
+            public ResultSet ComparatorSets => VerifyResult(_results);
+        }
+
+        /// <summary>
+        /// <para>
         /// Implements parsing for version ranges.
         /// </para>
         /// </summary>
-        private static class Parser
+        internal static class Parser
         {
 
         }

--- a/libSemVer.NET/Ranges/VersionRange.Parsing.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Parsing.cs
@@ -1031,5 +1031,53 @@ namespace McSherry.SemanticVersioning.Ranges
                 return _parseString(rangeString);
             }
         }
+
+        /// <summary>
+        /// <para>
+        /// Parses a version range from a string.
+        /// </para>
+        /// </summary>
+        /// <param name="range">
+        /// The string representing the version range.
+        /// </param>
+        /// <returns>
+        /// A <see cref="VersionRange"/> equivalent to the
+        /// value of <paramref name="range"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="range"/> is null, empty,
+        /// or contains only whitespace characters.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="range"/> is invalid for any
+        /// reason unrelated to an invalid semantic version string.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Thrown when <paramref name="range"/> contains an invalid
+        /// semantic version string.
+        /// </exception>
+        public static VersionRange Parse(string range)
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Attempts to parse a version range from a string.
+        /// </para>
+        /// </summary>
+        /// <param name="range">
+        /// The string representing the version range.
+        /// </param>
+        /// <param name="result">
+        /// The <see cref="VersionRange"/> that, on success, is
+        /// given a value equivalent to <paramref name="range"/>.
+        /// </param>
+        /// <returns>
+        /// True on success, false on failure.
+        /// </returns>
+        public static bool TryParse(string range, out VersionRange result)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/libSemVer.NET/Ranges/VersionRange.Parsing.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Parsing.cs
@@ -21,7 +21,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 using static McSherry.SemanticVersioning.Ranges.VersionRange.ParseResultType;
 

--- a/libSemVer.NET/Ranges/VersionRange.Parsing.cs
+++ b/libSemVer.NET/Ranges/VersionRange.Parsing.cs
@@ -79,7 +79,7 @@ namespace McSherry.SemanticVersioning.Ranges
         /// grouping identified by the parser.
         /// </para>
         /// </summary>
-        private struct Comparator
+        private struct ComparatorToken
         {
             private readonly Operator _op;
             private readonly SemanticVersion _sv;
@@ -120,7 +120,7 @@ namespace McSherry.SemanticVersioning.Ranges
 
             /// <summary>
             /// <para>
-            /// Creates a new <see cref="Comparator"/> instance with
+            /// Creates a new <see cref="ComparatorToken"/> instance with
             /// the specified operator and semantic version.
             /// </para>
             /// </summary>
@@ -137,7 +137,7 @@ namespace McSherry.SemanticVersioning.Ranges
             /// Thrown when <paramref name="op"/> is not a recognised
             /// <see cref="VersionRange.Operator"/>.
             /// </exception>
-            public Comparator(Operator op, SemanticVersion semver)
+            public ComparatorToken(Operator op, SemanticVersion semver)
             {
                 if (semver == null)
                 {

--- a/libSemVer.NET/Ranges/VersionRange.cs
+++ b/libSemVer.NET/Ranges/VersionRange.cs
@@ -36,6 +36,10 @@ namespace McSherry.SemanticVersioning.Ranges
 
         Ranges\VersionRange.Parsing.cs:
             Parsing ranges, comparators, etc, from strings.
+
+        Ranges\VersionRange.Comparison.cs:
+            Implementation of comparators and comparisons, works
+            with the output of the parser to provide usable methods.
     */
 
     /// <summary>
@@ -59,6 +63,136 @@ namespace McSherry.SemanticVersioning.Ranges
     [CLSCompliant(true)]
     public sealed partial class VersionRange
     {
+        // Used as a passthrough method so that the constructor taking a string
+        // argument can use constructor chaining to avoid duplicate code.
+        private static IEnumerable<IEnumerable<IComparator>> _ctorPassthrough(
+            string range
+            )
+        {
+            // First step, pass the string through the parser so we can
+            // get a result to work with.
+            var parseResult = Parser.Parse(range);
+
+            // If the parsing was not successful, then we want to create an
+            // exception and throw it.
+            if (parseResult.Type != ParseResultType.Success)
+                throw parseResult.CreateException();
+
+            // If it was successful, then we want to transform the parser
+            // output into something that we can return to our caller.
+            //
+            // The parser returns [ComparatorToken]s, which represent
+            // individual comparators in a comparator set, but have no
+            // actual implementation. We need to hand these tokens off
+            // to our [Comparator] class, which will provide us with an
+            // [IComparator] instance we can use.
+            return parseResult.ComparatorSets.Select(
+                tokenSet => tokenSet.Select(
+                    token => Comparator.Create(token)
+                    )
+                );
+        }
+
+        // The comparators that make up the version range. For ease of
+        // use, each [IComparator] represents a set rather than an
+        // individual comparator here.
+        private readonly IEnumerable<IEnumerable<IComparator>> _comparators;
+        // A cache of versions that match and that don't match so that
+        // many repeated comparisons might be sped up a bit.
+        private readonly ISet<SemanticVersion> _matches, _mismatches;
+
+        /// <summary>
+        /// <para>
+        /// Creates a new <see cref="VersionRange"/> instance from a set
+        /// of comparator sets.
+        /// </para>
+        /// </summary>
+        /// <param name="cmps">
+        /// The set of comparator sets to create an instance from.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="cmps"/> or any of its members are
+        /// null or contain null values.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="cmps"/> is empty, or contains an
+        /// empty set.
+        /// </exception>
+        private VersionRange(IEnumerable<IEnumerable<IComparator>> cmps)
+        {
+            // A one-liner for checking that the set of sets is not null, that
+            // it does not contain any null sets, and that those sets do not
+            // contain any null items.
+            //
+            // This probably warrants some explanation, since it can be a bit
+            // obtuse on first reading.
+            //
+            // [set?.Any(cmp => cmp == null)] will return a [bool?]. If [set]
+            // is null, then [null] is returned. Otherwise, the result of the
+            // predicate is returned. If the returned [bool?] is [true] or
+            // [null], it means that there is a null item. To make this into
+            // a workable condition, we instead check that it isn't false.
+            //
+            // The same applies for the outer predicate, except this time it's
+            // over a set of sets rather than a set of comparators.
+            if (cmps?.Any(set => set?.Any(cmp => cmp == null) != false) != false)
+            {
+                throw new ArgumentNullException(
+                    paramName:  nameof(cmps),
+                    message:    "The provided set of comparator sets cannot be " +
+                                "null, cannot contain null sets, and cannot " +
+                                "have a set containing a null item."
+                    );
+            }
+
+            // Make sure that the set of comparator sets is not empty, and does
+            // not contain any empty comparator sets.
+            if (!cmps.Any() || cmps.Any(set => !set.Any()))
+            {
+                throw new ArgumentException(
+                    message:    "The provided set of comparator sets cannot be " +
+                                "empty, and cannot contain any empty sets.",
+                    paramName:  nameof(cmps)
+                    );
+            }
+
+            // We've checked the provided comparators, so we're free to add them
+            // to our field for comparators. We're going to assume that whoever
+            // passed us the collection isn't going to modify it so we can avoid
+            // copying the contents.
+            _comparators = cmps;
+            // We're using [HashSet<T>]s for our caches because they're fast and
+            // because we only need to know whether a [SemanticVersion] is in
+            // there.
+            _matches = new HashSet<SemanticVersion>();
+            _mismatches = new HashSet<SemanticVersion>();
+        }
+        /// <summary>
+        /// <para>
+        /// Creates a version range from a string representing the range.
+        /// </para>
+        /// </summary>
+        /// <param name="range">
+        /// The version range string from which to create an instance.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="range"/> is null, empty,
+        /// or contains only whitespace characters.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="range"/> is invalid for any
+        /// reason unrelated to an invalid semantic version string.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Thrown when <paramref name="range"/> contains an invalid
+        /// semantic version string.
+        /// </exception>
+        public VersionRange(string range)
+            : this(_ctorPassthrough(range))
+        {
+            // See implementation of [_ctorPassthrough].
+        }
+
         /// <summary>
         /// <para>
         /// Determines whether the current version range is
@@ -75,7 +209,36 @@ namespace McSherry.SemanticVersioning.Ranges
         /// </returns>
         public bool SatisfiedBy(SemanticVersion semver)
         {
-            throw new NotImplementedException();
+            // If this is a known match, return true.
+            if (_matches.Contains(semver))
+                return true;
+
+            // If it's a known non-match, return false.
+            if (_mismatches.Contains(semver))
+                return false;
+
+            // If it's not in the cache, run it against our comparators
+            // to check whether it's a match or not.
+            //
+            // The [_comparators] variable contains all of the comparator
+            // sets that were parsed from the string, and only one of the
+            // comparator sets has to be satisfied for the range to be
+            // satisfied.
+            var result = _comparators.Any(
+                // Each comparator set has a number of comparators in it,
+                // and for a comparator set to be satisfied all of the
+                // comparators in that set must be satisfied.
+                set => set.All(
+                    cmp => cmp.SatisfiedBy(semver)
+                    )
+                );
+
+            // We know whether it matches or not now, so we add it to the
+            // appropriate cache so that it is known for future checks.
+            (result ? _matches : _mismatches).Add(semver);
+
+            // Result cached, we can now return that result to our caller.
+            return result;
         }
         /// <summary>
         /// <para>

--- a/libSemVer.NET/Ranges/VersionRange.cs
+++ b/libSemVer.NET/Ranges/VersionRange.cs
@@ -94,9 +94,10 @@ namespace McSherry.SemanticVersioning.Ranges
                 );
         }
 
-        // The comparators that make up the version range. For ease of
-        // use, each [IComparator] represents a set rather than an
-        // individual comparator here.
+        // The comparators that make up the version range. Each [IComparator]
+        // is an individual comparator, so we need two [IEnumerable<T>] wraps:
+        // one for comparator sets, and one to contain the multiple comparator
+        // sets that make up the version range.
         private readonly IEnumerable<IEnumerable<IComparator>> _comparators;
         // A cache of versions that match and that don't match so that
         // many repeated comparisons might be sped up a bit.

--- a/libSemVer.NET/Ranges/VersionRange.cs
+++ b/libSemVer.NET/Ranges/VersionRange.cs
@@ -19,10 +19,7 @@
 // SOFTWARE.
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace McSherry.SemanticVersioning.Ranges
 {
@@ -44,19 +41,23 @@ namespace McSherry.SemanticVersioning.Ranges
 
     /// <summary>
     /// <para>
-    /// Represents a range of <see cref="SemanticVersion"/> values.
+    /// Represents a range of acceptable versions. This class cannot
+    /// be inherited.
     /// </para>
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// A version range specifies a set of semantic versions that are
+    /// acceptable, and is used to check that a given semantic version
+    /// fits within this set.
+    /// </para>
     /// <para>
     /// Version ranges use the <c>node-semver</c> syntax for ranges.
     /// Specifically, ranges are based on the specification as it was
     /// written for the v5.0.0 release of <c>node-semver</c>.
     /// </para>
     /// <para>
-    /// Presently, only the "basic" ranges syntax is supported. That is,
-    /// any features under the "Advanced Range Syntax" heading are not
-    /// supported.
+    /// Presently, only the basic range syntax is supported.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/libSemVer.NET/Ranges/VersionRange.cs
+++ b/libSemVer.NET/Ranges/VersionRange.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) 2015 Liam McSherry
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace McSherry.SemanticVersioning.Ranges
+{
+
+    /*
+        The implementation of this class is split across
+        multiple files.
+
+        Ranges\VersionRange.cs:
+            Main implementation.
+
+        Ranges\VersionRange.Parsing.cs:
+            Parsing ranges, comparators, etc, from strings.
+    */
+
+    /// <summary>
+    /// <para>
+    /// Represents a range of <see cref="SemanticVersion"/> values.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Version ranges use the <c>node-semver</c> syntax for ranges.
+    /// Specifically, ranges are based on the specification as it was
+    /// written for the v5.0.0 release of <c>node-semver</c>.
+    /// </para>
+    /// <para>
+    /// Presently, only the "basic" ranges syntax is supported. That is,
+    /// any features under the "Advanced Range Syntax" heading are not
+    /// supported.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [CLSCompliant(true)]
+    public sealed partial class VersionRange
+    {
+        /// <summary>
+        /// <para>
+        /// Determines whether the current version range is
+        /// satisfied by a specified <see cref="SemanticVersion"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="semver">
+        /// The <see cref="SemanticVersion"/> to check against the
+        /// current version range.
+        /// </param>
+        /// <returns>
+        /// True if the current version range is satisfied by
+        /// <paramref name="semver"/>, false if otherwise.
+        /// </returns>
+        public bool SatisfiedBy(SemanticVersion semver)
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// <para>
+        /// Determines whether the current version range is satisfied
+        /// by all specified <see cref="SemanticVersion"/> instances.
+        /// </para>
+        /// </summary>
+        /// <param name="semvers">
+        /// The <see cref="SemanticVersion"/> instances to check
+        /// against the current version range.
+        /// </param>
+        /// <returns>
+        /// True if all <see cref="SemanticVersion"/> instances in
+        /// <paramref name="semvers"/> satisfy the current version
+        /// range, false if otherwise.
+        /// </returns>
+        public bool SatisfiedBy(params SemanticVersion[] semvers)
+        {
+            return semvers.All(this.SatisfiedBy);
+        }
+    }
+}

--- a/libSemVer.NET/SemanticVersion.Parsing.cs
+++ b/libSemVer.NET/SemanticVersion.Parsing.cs
@@ -194,8 +194,8 @@ namespace McSherry.SemanticVersioning
                     return passthrough;
 
                 throw new InvalidOperationException(
-                    "Attempt to use a [ParseResult] that was default-" +
-                    "constructed.");
+                    "Attempt to use a [SemanticVersion.ParseResult] that " +
+                    "was default-constructed.");
             }
 
             /// <summary>
@@ -250,7 +250,7 @@ namespace McSherry.SemanticVersioning
                 if (error == ParseResultType.Success)
                 {
                     throw new ArgumentException(
-                        message:    "A failure-state ParseResult cannot be " +
+                        message:    "A failure-state SV.ParseResult cannot be " +
                                     "created with the [Success] status.",
                         paramName:  nameof(error));
                 }

--- a/libSemVer.NET/libSemVer.NET.csproj
+++ b/libSemVer.NET/libSemVer.NET.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Helper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Ranges\VersionRange.Comparison.cs" />
     <Compile Include="Ranges\VersionRange.cs" />
     <Compile Include="Ranges\VersionRange.Parsing.cs" />
     <Compile Include="SemanticVersion.cs" />

--- a/libSemVer.NET/libSemVer.NET.csproj
+++ b/libSemVer.NET/libSemVer.NET.csproj
@@ -48,6 +48,8 @@
   <ItemGroup>
     <Compile Include="Helper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Ranges\VersionRange.cs" />
+    <Compile Include="Ranges\VersionRange.Parsing.cs" />
     <Compile Include="SemanticVersion.cs" />
     <Compile Include="SemanticVersion.Formatting.cs" />
     <Compile Include="SemanticVersion.Parsing.cs" />


### PR DESCRIPTION
### What are version ranges?

Version ranges make it easy to specify complex conditions that a semantic version has to meet. They use a string containing a set of versions with associated operators to specify the conditions that must be met. For example, `>1.5.0` would be used to match any version with greater precedence than `v1.5.0`. 

These can be combined as **comparator sets** to specify multiple conditions that must be fulfilled (e.g. `>1.0.0 <2.0.0`), and multiple comparator sets can be specified to give a set of conditions where only one needs to be fulfilled (for example, if you wanted versions greater than `v1.5.0` _or_ just version `v1.4.6`, you would use two comparator sets: `>1.5.0` and `=1.4.6`, using the syntax `>1.5.0 || =1.4.6`).

 
### What is the version range syntax?

The [`node-semver`][1] syntax is used. Presently, only the basic features are supported, and the `v5.0.0` revision of the specification is used. This includes allowing versions to be prefixed (`>1.5.0`, `>v1.5.0`, and `>V1.5.0` are considered equivalent) and implicit use of the equality operator (`=1.5.0` and `1.5.0` are equivalent).

[1]: https://github.com/npm/node-semver

#### Will the "advanced" syntax be supported in future?

Probably. Exactly when is uncertain, but it's something I want to do.


### Why is this in a pull request?

So I have somewhere convenient to link to in release notes, since I don't want to go into detail on version ranges in the release notes.